### PR TITLE
Bugfixes for 1.9

### DIFF
--- a/burger/toppings/items.py
+++ b/burger/toppings/items.py
@@ -90,6 +90,8 @@ class ItemsTopping(Topping):
                     item["icon"] = {"x": stack[0], "y": stack[1]}
                 elif len(stack) == 1:
                     if isinstance(stack[0], str):
+                        if "name" in item:
+                            continue
                         item["name"] = stack[0]
                         language_key = "%s.name" % stack[0]
                         if language != None and language_key in language:


### PR DESCRIPTION
- The item class has a new method which was confused with the one setting the name.
- Some packets now call methods of the packet superclass which wasn't handled correctly.
