### PR TITLE
Fix entities and language toppings to work with 16w32a

### DIFF
--- a/burger/toppings/language.py
+++ b/burger/toppings/language.py
@@ -54,6 +54,12 @@ class LanguageTopping(Topping):
             "assets/minecraft/lang/en_US.lang",
             verbose
         )
+        LanguageTopping.load_language(
+            aggregate,
+            jar,
+            "assets/minecraft/lang/en_us.lang",
+            verbose
+        )
 
     @staticmethod
     def load_language(aggregate, jar, path, verbose=False):

--- a/burger/toppings/sounds.py
+++ b/burger/toppings/sounds.py
@@ -40,7 +40,7 @@ try:
 except ImportError:
     from StringIO import StringIO
 
-ASSET_INDEX = "https://s3.amazonaws.com/Minecraft.Download/indexes/1.9.json"
+ASSET_INDEX = "https://s3.amazonaws.com/Minecraft.Download/indexes/1.11.json"
 RESOURCES_SITE = "http://resources.download.minecraft.net/%s/%s"
 
 def get_asset_index(url=ASSET_INDEX):


### PR DESCRIPTION
Mojang significantly changed the way entities were registered in 16w32a, necessitating separate logic for reading them between versions.  The change to the language topping is because language files are now lowercase; nothing major.  The sounds topping change makes it so that the 1.11 sound index is used, though right now that may still be the wrong index for earlier versions; future work to use the appropriate index is necessary.