### PR TITLE
Add states to packet data

### DIFF
--- a/burger/toppings/packets.py
+++ b/burger/toppings/packets.py
@@ -198,7 +198,8 @@ class PacketsTopping(Topping):
                         "class": stack[1],
                         "direction": direction,
                         "from_client": from_client(method_name),
-                        "from_server": from_server(method_name)
+                        "from_server": from_server(method_name),
+                        "state": state_name
                     }
                     stack = []
 


### PR DESCRIPTION
We're already getting the state for the packet name, but as @MylesIsCool pointed out, it's useful to have the state within the packet itself as well.