### PR TITLE
1.12 fixes

### DIFF
--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -115,6 +115,20 @@ def identify(class_file):
             if public_register_method and private_register_method:
                 return 'sounds.event', class_file.this.name.value
 
+        if value == 'minecraft':
+            # Look for two protected final strings
+            def is_protected_final(m):
+                return m.access_flags.acc_protected and m.access_flags.acc_final
+
+            find_args = {
+                "type_": "Ljava/lang/String;",
+                "f": is_protected_final
+            }
+            fields = class_file.fields.find(**find_args)
+
+            if len(list(fields)) == 2:
+                return 'identifier', class_file.this.name.value
+
 
 class IdentifyTopping(Topping):
     """Finds important superclasses needed by other toppings."""
@@ -140,7 +154,8 @@ class IdentifyTopping(Topping):
         "identify.sounds.event",
         "identify.sounds.list",
         "identify.tileentity.superclass",
-        "identify.tileentity.blockentitytag"
+        "identify.tileentity.blockentitytag",
+        "identify.resourcelocation"
     ]
 
     DEPENDS = []

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -45,40 +45,42 @@ def identify(class_file):
     # We can identify almost every class we need just by
     # looking for consistent strings.
     matches = (
-        ('Accessed Biomes before Bootstrap!', 'biome.list'),  # 1.9 only
-        ('Ice Plains', 'biome.superclass'),
-        ('Accessed Blocks before Bootstrap!', 'block.list'),
-        ('lightgem', 'block.superclass'),
-        ('Skipping Entity with id', 'entity.list'),
-        ('Fetching addPacket for removed entity', 'entity.trackerentry'),
-        ('Accessed Items before Bootstrap!', 'item.list'),
-        ('yellowDust', 'item.superclass'),
-        ('#%04d/%d%s', 'itemstack'),
-        ('disconnect.lost', 'nethandler.client'),
-        ('Outdated server!', 'nethandler.server'),
-        ('Corrupt NBT tag', 'nbtcompound'),
-        (' is already assigned to protocol ', 'packet.connectionstate'),
+        (['Accessed Biomes before Bootstrap!'], 'biome.list'),  # 1.9 only
+        (['Ice Plains'], 'biome.superclass'),
+        (['Accessed Blocks before Bootstrap!'], 'block.list'),
+        (['lightgem'], 'block.superclass'),
+        (['Skipping Entity with id'], 'entity.list'),
+        (['Fetching addPacket for removed entity'], 'entity.trackerentry'),
+        (['Accessed Items before Bootstrap!'], 'item.list'),
+        (['yellowDust'], 'item.superclass'),
+        (['#%04d/%d%s'], 'itemstack'),
+        (['disconnect.lost'], 'nethandler.client'),
+        (['Outdated server!', 'multiplayer.disconnect.outdated_client'],
+            'nethandler.server'),
+        (['Corrupt NBT tag'], 'nbtcompound'),
+        ([' is already assigned to protocol '], 'packet.connectionstate'),
         (
-            'The received encoded string buffer length is ' \
-            'less than zero! Weird string!',
+            ['The received encoded string buffer length is ' \
+            'less than zero! Weird string!'],
             'packet.packetbuffer'
         ),
-        ('Data value id is too big', 'metadata'),
-        ('X#X', 'recipe.superclass'),
-        ('Accessed Sounds before Bootstrap!', 'sounds.list'),
-        ('Skipping BlockEntity with id ', 'tileentity.superclass'),
+        (['Data value id is too big'], 'metadata'),
+        (['X#X'], 'recipe.superclass'),
+        (['Accessed Sounds before Bootstrap!'], 'sounds.list'),
+        (['Skipping BlockEntity with id '], 'tileentity.superclass'),
         (
-            'Unable to resolve BlockEntity for ItemInstance:',
+            ['Unable to resolve BlockEntity for ItemInstance:'],
             'tileentity.blockentitytag'
         )
     )
     for c in class_file.constants.find(ConstantString):
         value = c.string.value
-        for match, match_name in matches:
-            if match not in value:
-                continue
+        for match_list, match_name in matches:
+            for match in match_list:
+                if match not in value:
+                    continue
 
-            return match_name, class_file.this.name.value
+                return match_name, class_file.this.name.value
         if 'BaseComponent' in value:
             # We want the interface for chat components, but it has no
             # string constants, so we need to use the abstract class and then

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -96,16 +96,16 @@ def identify(class_file):
                 return m.access_flags.acc_public and m.access_flags.acc_static
 
             def is_private_static(m):
-                return m.access_flags.acc_public and m.access_flags.acc_static
+                return m.access_flags.acc_private and m.access_flags.acc_static
 
             pub_args = {
                 "args": "",
-                "returns": "",
+                "returns": "V",
                 "f": is_public_static
             }
             priv_args = {
-                "args": "",
-                "returns": "",
+                "args": "Ljava/lang/String;",
+                "returns": "V",
                 "f": is_private_static
             }
 

--- a/burger/toppings/packetinstructions.py
+++ b/burger/toppings/packetinstructions.py
@@ -215,8 +215,8 @@ class PacketInstructionsTopping(Topping):
             if len(methods) == 2:
                 method = methods[1]
             else:
-                if cf.super_:
-                    return _PIT.operations(jar, cf.super_.name + ".class", classes)
+                if cf.super_.name.value != "java/lang/Object":
+                    return _PIT.operations(jar, cf.super_.name.value + ".class", classes)
                 else:
                     raise Exception("Failed to find method in class or superclass")
         elif methodname is None:

--- a/burger/toppings/packetinstructions.py
+++ b/burger/toppings/packetinstructions.py
@@ -53,7 +53,8 @@ class PacketInstructionsTopping(Topping):
         "identify.nbtcompound",
         "identify.itemstack",
         "identify.chatcomponent",
-        "identify.metadata"
+        "identify.metadata",
+        "identify.resourcelocation"
     ]
 
     TYPES = {
@@ -334,6 +335,10 @@ class PacketInstructionsTopping(Topping):
                 elif num_arguments == 1 and descriptor.args[0].name == classes["chatcomponent"]:
                     operations.append(Operation(instruction.pos, "write",
                                                 type="chatcomponent",
+                                                field=stack.pop()))
+                elif num_arguments == 1 and descriptor.args[0].name == classes["identifier"]:
+                    operations.append(Operation(instruction.pos, "write",
+                                                type="identifier",
                                                 field=stack.pop()))
                 else:
                     if num_arguments > 0:

--- a/burger/toppings/recipes.py
+++ b/burger/toppings/recipes.py
@@ -126,6 +126,9 @@ class RecipesTopping(Topping):
                     recipe = {}
                     recipe["id"] = recipe_id # new for 1.12, but used ingame
 
+                    if "group" in data:
+                        recipe["group"] = data["group"]
+
                     recipe["makes"] = parse_item(data["result"], False)
                     if "count" not in recipe["makes"]:
                         recipe["makes"]["count"] = 1 # default, TODO should we keep specifying this?

--- a/burger/toppings/recipes.py
+++ b/burger/toppings/recipes.py
@@ -77,6 +77,11 @@ class RecipesTopping(Topping):
 
         def parse_item(blob):
             """ Converts a JSON item into a burger item"""
+            # TODO: This converts a list into a single item, in a bad, data-losing way.
+            # However, handling it more cleanly is hard, due to backwards compatibility.
+            # As such, a TOTAL HACK of taking just the first element is used.
+            if isinstance(blob, list):
+                blob = blob[0]
             # There's some wierd stuff regarding 0 or 32767 here; I'm not worrying about it though
             # Probably 0 is the default for results, and 32767 means "any" for ingredients
             assert "item" in blob

--- a/burger/toppings/version.py
+++ b/burger/toppings/version.py
@@ -52,10 +52,14 @@ class VersionTopping(Topping):
                 for instr in method.code.disassemble():
                     if instr.mnemonic in ("bipush", "sipush"):
                         version = instr.operands[0].value
+                    elif instr.mnemonic.startswith("iconst"):
+                        version = int(instr.mnemonic[-1])
                     elif instr.mnemonic == "ldc" and version is not None:
                         constant = cf.constants.get(instr.operands[0].value)
                         if isinstance(constant, ConstantString):
-                            if "Outdated server!" in constant.string.value:
+                            str = constant.string.value
+                            if "multiplayer.disconnect.outdated_client" \
+                                    in str or "Outdated server!" in str:
                                 versions["protocol"] = version
                                 return
         elif verbose:


### PR DESCRIPTION
These commits make burger work with 1.12, dealing with the changes to the recipe format and some new packets.

Note that 26087bf is pretty hacky; I haven't come up with the perfect solution there.  The reason for that is because recipes in 1.12 can have different ingredients in a single JSON file, and all ingredients need to be listed as separate results in burger (we can't use a list of items there).  The result is fairly ugly; suggestions on how to do it better would be appreciated.