### PR TITLE
Make use of Jawa's equality shorthands

### DIFF
--- a/burger/toppings/blocks.py
+++ b/burger/toppings/blocks.py
@@ -144,7 +144,7 @@ class BlocksTopping(Topping):
                 desc = method_descriptor(method_desc)
 
                 if ins == "invokestatic":
-                    if const.class_.name.value == superclass:
+                    if const.class_.name == superclass:
                         # Call to the static register method.
                         text_id = args[0]
                         current_block = args[1]
@@ -156,7 +156,7 @@ class BlocksTopping(Topping):
                             current_block["display_name"] = language[lang_key]
                         block[text_id] = current_block
                         ordered_blocks.append(text_id)
-                    elif const.class_.name.value == builder_class:
+                    elif const.class_.name == builder_class:
                         if desc.args[0].name == superclass: # Copy constructor
                             copy = dict(args[0])
                             del copy["text_id"]
@@ -173,16 +173,16 @@ class BlocksTopping(Topping):
                         # (and have started iterating over registry keys)
                         raise StopIteration()
 
-                    if method_name == hardness_setter.name.value and method_desc == hardness_setter.descriptor.value:
+                    if method_name == hardness_setter.name and method_desc == hardness_setter.descriptor:
                         obj["hardness"] = args[0]
                         obj["resistance"] = args[1]
-                    elif method_name == hardness_setter_2.name.value and method_desc == hardness_setter_2.descriptor.value:
+                    elif method_name == hardness_setter_2.name and method_desc == hardness_setter_2.descriptor:
                         obj["hardness"] = args[0]
                         obj["resistance"] = args[0]
-                    elif method_name == hardness_setter_3.name.value and method_desc == hardness_setter_3.descriptor.value:
+                    elif method_name == hardness_setter_3.name and method_desc == hardness_setter_3.descriptor:
                         obj["hardness"] = 0.0
                         obj["resistance"] = 0.0
-                    elif method_name == light_setter.name.value and method_desc == light_setter.descriptor.value:
+                    elif method_name == light_setter.name and method_desc == light_setter.descriptor:
                         obj["light"] = args[0]
                     elif method_name == "<init>":
                         # Call to the constructor for the block
@@ -200,7 +200,7 @@ class BlocksTopping(Topping):
                         return object()
 
             def on_get_field(self, ins, const, obj):
-                if const.class_.name.value == superclass:
+                if const.class_.name == superclass:
                     # Probably getting the static AIR resource location
                     return "air"
                 else:
@@ -273,7 +273,7 @@ class BlocksTopping(Topping):
                     stack.append(const.value)
             elif ins == "getstatic":
                 const = ins.operands[0]
-                if const.class_.name.value == superclass:
+                if const.class_.name == superclass:
                     # Probably getting the static AIR resource location
                     stack.append("air")
                 else:

--- a/burger/toppings/blockstates.py
+++ b/burger/toppings/blockstates.py
@@ -93,22 +93,22 @@ class BlockStateTopping(Topping):
                 # This could _almost_ just be checking for getstatic, but
                 # brewing stands use an array of properties as the field,
                 # so we need some stupid extra logic.
-                if ins.mnemonic == "new":
+                if ins == "new":
                     assert not is_18w19a # In 18w19a this should be a parameter
                     const = ins.operands[0]
                     type_name = const.name.value
                     assert type_name == blockstatecontainer
                     stack.append(object())
-                elif ins.mnemonic == "aload" and ins.operands[0].value == 1:
+                elif ins == "aload" and ins.operands[0].value == 1:
                     assert is_18w19a # The parameter is only used in 18w19a and above
                     stack.append(object())
-                elif ins.mnemonic in ("sipush", "bipush"):
+                elif ins in ("sipush", "bipush"):
                     stack.append(ins.operands[0].value)
-                elif ins.mnemonic in ("anewarray", "newarray"):
+                elif ins in ("anewarray", "newarray"):
                     length = stack.pop()
                     val = [None] * length
                     stack.append(val)
-                elif ins.mnemonic == "getstatic":
+                elif ins == "getstatic":
                     const = ins.operands[0]
                     prop = {
                         "field_name": const.name_and_type.name.value
@@ -116,20 +116,20 @@ class BlockStateTopping(Topping):
                     desc = field_descriptor(const.name_and_type.descriptor.value)
                     _property_types.add(desc.name)
                     stack.append(prop)
-                elif ins.mnemonic == "aaload":
+                elif ins == "aaload":
                     index = stack.pop()
                     array = stack.pop()
                     prop = array.copy()
                     prop["array_index"] = index
                     stack.append(prop)
-                elif ins.mnemonic == "aastore":
+                elif ins == "aastore":
                     value = stack.pop()
                     index = stack.pop()
                     array = stack.pop()
                     array[index] = value
-                elif ins.mnemonic == "dup":
+                elif ins == "dup":
                     stack.append(stack[-1])
-                elif ins.mnemonic == "invokespecial":
+                elif ins == "invokespecial":
                     const = ins.operands[0]
                     assert const.name_and_type.name.value == "<init>"
                     desc = method_descriptor(const.name_and_type.descriptor.value)
@@ -142,7 +142,7 @@ class BlockStateTopping(Topping):
                     stack.pop() # Block
                     stack.pop() # Invocation target
                     stack.append(arg)
-                elif ins.mnemonic == "invokevirtual":
+                elif ins == "invokevirtual":
                     # Two possibilities (both only present pre-flattening):
                     # 1. It's isDouble() for a slab.  Two different sets of
                     #    properties in that case.
@@ -173,12 +173,12 @@ class BlockStateTopping(Topping):
                         # for properties
                         stack.pop() # Target object
                         stack.append(None)
-                elif ins.mnemonic == "ifeq":
+                elif ins == "ifeq":
                     assert if_pos is None
                     if_pos = ins.pos + ins.operands[0].value
-                elif ins.mnemonic == "pop":
+                elif ins == "pop":
                     stack.pop()
-                elif ins.mnemonic == "areturn":
+                elif ins == "areturn":
                     assert not is_18w19a # In 18w19a we don't return a container
                     if if_pos == None:
                         assert properties == None
@@ -188,9 +188,9 @@ class BlockStateTopping(Topping):
                         index = 0 if ins.pos < if_pos else 1
                         assert properties[index] == None
                         properties[index] = stack.pop()
-                elif ins.mnemonic == "return":
+                elif ins == "return":
                     assert is_18w19a # We only return void in 18w19a
-                elif ins.mnemonic == "aload":
+                elif ins == "aload":
                     assert ins.operands[0].value == 0 # Should be aload_0 (this)
                     stack.append(object())
                 elif verbose:
@@ -299,7 +299,7 @@ class BlockStateTopping(Topping):
             ignore_remaining = False
 
             for ins in init.code.disassemble():
-                if ins.mnemonic == "putstatic":
+                if ins == "putstatic":
                     const = ins.operands[0]
                     name = const.name_and_type.name.value
                     if ignore_remaining:
@@ -324,7 +324,7 @@ class BlockStateTopping(Topping):
                     fields_by_class[cls][name] = value
                 elif ignore_remaining:
                     continue
-                elif ins.mnemonic == "getstatic":
+                elif ins == "getstatic":
                     const = ins.operands[0]
                     target = const.class_.name.value
                     type = field_descriptor(const.name_and_type.descriptor.value).name
@@ -333,7 +333,7 @@ class BlockStateTopping(Topping):
                         stack.append(find_field(target, name))
                     else:
                         stack.append(object())
-                elif ins.mnemonic in ("ldc", "ldc_w", "ldc2_w"):
+                elif ins in ("ldc", "ldc_w", "ldc2_w"):
                     const = ins.operands[0]
 
                     if isinstance(const, ConstantClass):
@@ -344,30 +344,30 @@ class BlockStateTopping(Topping):
                         stack.append(const.value)
                 elif ins.mnemonic.startswith("dconst"):
                     stack.append(float(ins.mnemonic[-1]))
-                elif ins.mnemonic in ("bipush", "sipush"):
+                elif ins in ("bipush", "sipush"):
                     stack.append(ins.operands[0].value)
-                elif ins.mnemonic == "aconst_null":
+                elif ins == "aconst_null":
                     stack.append(None)
-                elif ins.mnemonic in ("anewarray", "newarray"):
+                elif ins in ("anewarray", "newarray"):
                     length = stack.pop()
                     stack.append([None] * length)
-                elif ins.mnemonic in ("aaload", "iaload"):
+                elif ins in ("aaload", "iaload"):
                     index = stack.pop()
                     array = stack.pop()
                     prop = array[index].copy()
                     prop["array_index"] = index
                     stack.append(prop)
-                elif ins.mnemonic in ("aastore", "iastore"):
+                elif ins in ("aastore", "iastore"):
                     value = stack.pop()
                     index = stack.pop()
                     array = stack.pop()
                     array[index] = value
-                elif ins.mnemonic == "arraylength":
+                elif ins == "arraylength":
                     array = stack.pop()
                     stack.append(len(array))
-                elif ins.mnemonic == "dup":
+                elif ins == "dup":
                     stack.append(stack[-1])
-                elif ins.mnemonic == "invokedynamic":
+                elif ins == "invokedynamic":
                     # Try to get the class that's being created
                     const = ins.operands[0]
                     desc = method_descriptor(const.name_and_type.descriptor.value)
@@ -379,7 +379,7 @@ class BlockStateTopping(Topping):
                     args = [stack.pop() for _ in six.moves.range(num_args)]
                     args.reverse()
 
-                    if ins.mnemonic == "invokestatic":
+                    if ins == "invokestatic":
                         if const.class_.name.value.startswith("com/google/"):
                             # Call to e.g. Maps.newHashMap, beyond what we
                             # care about
@@ -420,13 +420,13 @@ class BlockStateTopping(Topping):
                         else:
                             o = object()
                             stack.append(o)
-                elif ins.mnemonic in ("istore", "lstore", "fstore", "dstore", "astore"):
+                elif ins in ("istore", "lstore", "fstore", "dstore", "astore"):
                     # Store other than array store
                     locals[ins.operands[0].value] = stack.pop()
-                elif ins.mnemonic in ("iload", "lload", "fload", "dload", "aload"):
+                elif ins in ("iload", "lload", "fload", "dload", "aload"):
                     # Load other than array load
                     stack.append(locals[ins.operands[0].value])
-                elif ins.mnemonic == "new":
+                elif ins == "new":
                     const = ins.operands[0]
                     type_name = const.name.value
                     obj = {
@@ -434,12 +434,12 @@ class BlockStateTopping(Topping):
                         "is_enum": is_enum(type_name)
                     }
                     stack.append(obj)
-                elif ins.mnemonic == "checkcast":
+                elif ins == "checkcast":
                     # We don't have type information, so no checking or casting
                     pass
-                elif ins.mnemonic == "return":
+                elif ins == "return":
                     break
-                elif ins.mnemonic == "if_icmpge":
+                elif ins == "if_icmpge":
                     # Code in stairs that loops over state combinations for hitboxes
                     break
                 elif verbose:

--- a/burger/toppings/blockstates.py
+++ b/burger/toppings/blockstates.py
@@ -131,7 +131,7 @@ class BlockStateTopping(Topping):
                     stack.append(stack[-1])
                 elif ins == "invokespecial":
                     const = ins.operands[0]
-                    assert const.name_and_type.name.value == "<init>"
+                    assert const.name_and_type.name == "<init>"
                     desc = method_descriptor(const.name_and_type.descriptor.value)
                     assert len(desc.args) == 2
 
@@ -156,7 +156,7 @@ class BlockStateTopping(Topping):
                     const = ins.operands[0]
                     desc = method_descriptor(const.name_and_type.descriptor.value)
 
-                    if const.class_.name.value == blockstatecontainer:
+                    if const.class_.name == blockstatecontainer:
                         # Case 3.
                         assert properties == None
                         properties = stack.pop()
@@ -396,13 +396,13 @@ class BlockStateTopping(Topping):
                             "args": args
                         }
                         stack.append(prop)
-                    elif const.name_and_type.name.value == "<init>":
+                    elif const.name_and_type.name == "<init>":
                         if obj["is_enum"]:
                             obj["enum_name"] = args[0]
                             obj["enum_ordinal"] = args[1]
                         else:
                             obj["args"] = args
-                    elif const.name_and_type.name.value == "values":
+                    elif const.name_and_type.name == "values":
                         # Enum values
                         fields = find_field(const.class_.name.value, None)
                         stack.append([fld for fld in fields

--- a/burger/toppings/entities.py
+++ b/burger/toppings/entities.py
@@ -89,15 +89,15 @@ class EntityTopping(Topping):
         stack = []
         numeric_id = 0
         for ins in method.code.disassemble():
-            if ins.mnemonic in ("ldc", "ldc_w"):
+            if ins in ("ldc", "ldc_w"):
                 const = ins.operands[0]
                 if isinstance(const, ConstantClass):
                     stack.append(const.name.value)
                 elif isinstance(const, String):
                     stack.append(const.string.value)
-            elif ins.mnemonic == "invokedynamic":
+            elif ins == "invokedynamic":
                 stack.append(class_from_invokedynamic(ins, cf))
-            elif ins.mnemonic == "putstatic":
+            elif ins == "putstatic":
                 if len(stack) in (2, 3):
                     if len(stack) == 3:
                         # In 18w07a, they added a parameter for the entity class,
@@ -134,7 +134,7 @@ class EntityTopping(Topping):
         stack = []
         minecart_info = {}
         for ins in method.code.disassemble():
-            if ins.mnemonic in ("ldc", "ldc_w"):
+            if ins in ("ldc", "ldc_w"):
                 const = ins.operands[0]
                 if isinstance(const, ConstantClass):
                     stack.append(const.name.value)
@@ -142,9 +142,9 @@ class EntityTopping(Topping):
                     stack.append(const.string.value)
                 else:
                     stack.append(const.value)
-            elif ins.mnemonic in ("bipush", "sipush"):
+            elif ins in ("bipush", "sipush"):
                 stack.append(ins.operands[0].value)
-            elif ins.mnemonic == "getstatic":
+            elif ins == "getstatic":
                 # Minecarts use an enum for their data - assume that this is that enum
                 const = ins.operands[0]
                 if not "types_by_field" in minecart_info:
@@ -152,7 +152,7 @@ class EntityTopping(Topping):
                 # This technically happens when invokevirtual is called, but do it like this for simplicity
                 minecart_name = minecart_info["types_by_field"][const.name_and_type.name.value]
                 stack.append(minecart_info["types"][minecart_name]["entitytype"])
-            elif ins.mnemonic == "invokestatic":
+            elif ins == "invokestatic":
                 if len(stack) == 4:
                     # Initial registration
                     name = stack[1]
@@ -204,11 +204,11 @@ class EntityTopping(Topping):
             if mode == "starting":
                 # We don't care about the logger setup stuff at the beginning;
                 # wait until an entity definition starts.
-                if ins.mnemonic in ("ldc", "ldc_w"):
+                if ins in ("ldc", "ldc_w"):
                     mode = "entities"
             # elif is not used here because we need to handle modes changing
             if mode != "starting":
-                if ins.mnemonic in ("ldc", "ldc_w"):
+                if ins in ("ldc", "ldc_w"):
                     const = ins.operands[0]
                     if isinstance(const, ConstantClass):
                         stack.append(const.name.value)
@@ -216,15 +216,15 @@ class EntityTopping(Topping):
                         stack.append(const.string.value)
                     else:
                         stack.append(const.value)
-                elif ins.mnemonic in ("bipush", "sipush"):
+                elif ins in ("bipush", "sipush"):
                     stack.append(ins.operands[0].value)
-                elif ins.mnemonic == "new":
+                elif ins == "new":
                     # Entity aliases (for lack of a better term) start with 'new's.
                     # Switch modes (this operation will be processed there)
                     mode = "aliases"
                     const = ins.operands[0]
                     stack.append(const.name.value)
-                elif ins.mnemonic == "getstatic":
+                elif ins == "getstatic":
                     # Minecarts use an enum for their data - assume that this is that enum
                     const = ins.operands[0]
                     if not "types_by_field" in minecart_info:
@@ -232,7 +232,7 @@ class EntityTopping(Topping):
                     # This technically happens when invokevirtual is called, but do it like this for simplicity
                     minecart_name = minecart_info["types_by_field"][const.name_and_type.name.value]
                     stack.append(minecart_info["types"][minecart_name]["entitytype"])
-                elif ins.mnemonic == "invokestatic":  # invokestatic
+                elif ins == "invokestatic":  # invokestatic
                     if mode == "entities":
                         tmp["class"] = stack[0]
                         tmp["name"] = stack[1]
@@ -270,10 +270,10 @@ class EntityTopping(Topping):
 
         already_has_minecart_name = False
         for ins in init_method.code.disassemble():
-            if ins.mnemonic == "new":
+            if ins == "new":
                 const = ins.operands[0]
                 minecart_class = const.name.value
-            elif ins.mnemonic == "ldc":
+            elif ins == "ldc":
                 const = ins.operands[0]
                 if isinstance(const, String):
                     if already_has_minecart_name:
@@ -281,7 +281,7 @@ class EntityTopping(Topping):
                     else:
                         already_has_minecart_name = True
                         minecart_name = const.string.value
-            elif ins.mnemonic == "putstatic":
+            elif ins == "putstatic":
                 const = ins.operands[0]
                 if const.name_and_type.descriptor.value != "L" + classname + ";":
                     # Other parts of the enum initializer (values array) that we don't care about
@@ -309,9 +309,9 @@ class EntityTopping(Topping):
         tmp = []
         texture = None
         for ins in method.code.disassemble():
-            if ins.mnemonic == "aload" and ins.operands[0].value == 0 and stage == 0:
+            if ins == "aload" and ins.operands[0].value == 0 and stage == 0:
                 stage = 1
-            elif ins.mnemonic in ("ldc", "ldc_w"):
+            elif ins in ("ldc", "ldc_w"):
                 const = ins.operands[0]
                 if isinstance(const, Float) and stage in (1, 2):
                     tmp.append(round(const.value, 2))
@@ -321,7 +321,7 @@ class EntityTopping(Topping):
                     tmp = []
                     if isinstance(const, String):
                         texture = const.string.value
-            elif ins.mnemonic == "invokevirtual" and stage == 3:
+            elif ins == "invokevirtual" and stage == 3:
                 return tmp + [texture]
                 break
             else:

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -162,7 +162,7 @@ def identify(classloader, path):
             cf = classloader[path]
             logger_type = "Lorg/apache/logging/log4j/Logger;"
             while not cf.fields.find_one(type_=logger_type):
-                if cf.super_.name.value == "java/lang/Object":
+                if cf.super_.name == "java/lang/Object":
                     cf = None
                     break
                 cf = classloader[cf.super_.name.value]

--- a/burger/toppings/items.py
+++ b/burger/toppings/items.py
@@ -65,11 +65,11 @@ class ItemsTopping(Topping):
         method = lcf.methods.find_one(name="<clinit>")
         item_name = ""
         for ins in method.code.disassemble():
-            if ins.mnemonic in ("ldc", "ldc_w"):
+            if ins in ("ldc", "ldc_w"):
                 const = ins.operands[0]
                 if isinstance(const, String):
                     item_name = const.string.value
-            elif ins.mnemonic == "putstatic":
+            elif ins == "putstatic":
                 const = ins.operands[0]
                 field = const.name_and_type.name.value
                 if item_name in item_list:
@@ -101,7 +101,7 @@ class ItemsTopping(Topping):
         max_stack_method = None
         for method in builder_cf.methods.find(args='I'):
             for ins in method.code.disassemble():
-                if ins.mnemonic in ("ldc", "ldc_w"):
+                if ins in ("ldc", "ldc_w"):
                     const = ins.operands[0]
                     if isinstance(const, String) and const.string.value == "Unable to have damage AND stack.":
                         max_stack_method = method
@@ -113,7 +113,7 @@ class ItemsTopping(Topping):
         item_block_class = None
         # Find the class used that represents an item that is a block
         for ins in register_item_block_method.code.disassemble():
-            if ins.mnemonic == "new":
+            if ins == "new":
                 const = ins.operands[0]
                 item_block_class = const.name.value
                 break
@@ -150,7 +150,7 @@ class ItemsTopping(Topping):
                 method_desc = const.name_and_type.descriptor.value
                 desc = method_descriptor(method_desc)
 
-                if ins.mnemonic == "invokestatic":
+                if ins == "invokestatic":
                     if const.class_.name.value == superclass:
                         current_item = {}
 
@@ -216,7 +216,7 @@ class ItemsTopping(Topping):
 
                 if desc.returns.name != "void":
                     if desc.returns.name == builder_class or is_item_class(desc.returns.name):
-                        if ins.mnemonic == "invokestatic":
+                        if ins == "invokestatic":
                             # Probably returning itself, but through a synthetic method
                             return args[0]
                         else:
@@ -310,7 +310,7 @@ class ItemsTopping(Topping):
         item_block_class = None
         # Find the class used that represents an item that is a block
         for ins in register_item_block_method.code.disassemble():
-            if ins.mnemonic == "new":
+            if ins == "new":
                 const = ins.operands[0]
                 item_block_class = const.name.value
                 break
@@ -323,7 +323,7 @@ class ItemsTopping(Topping):
         tmp = []
 
         for ins in method.code.disassemble():
-            if ins.mnemonic == "new":
+            if ins == "new":
                 # The beginning of a new block definition
                 const = ins.operands[0]
                 class_name = const.name.value
@@ -359,9 +359,9 @@ class ItemsTopping(Topping):
                 stack = []
             elif ins.mnemonic.startswith("fconst"):
                 stack.append(float(ins.mnemonic[-1]))
-            elif ins.mnemonic in ("bipush", "sipush"):
+            elif ins in ("bipush", "sipush"):
                 stack.append(ins.operands[0].value)
-            elif ins.mnemonic in ("ldc", "ldc_w"):
+            elif ins in ("ldc", "ldc_w"):
                 const = ins.operands[0]
 
                 if isinstance(const, ConstantClass):
@@ -370,7 +370,7 @@ class ItemsTopping(Topping):
                     stack.append(const.string.value)
                 else:
                     stack.append(const.value)
-            elif ins.mnemonic in ("invokevirtual", "invokespecial"):
+            elif ins in ("invokevirtual", "invokespecial"):
                 # A method invocation
                 const = ins.operands[0]
                 method_name = const.name_and_type.name.value
@@ -378,12 +378,12 @@ class ItemsTopping(Topping):
                 current_item["calls"][method_name] = stack
                 current_item["calls"][method_name + method_desc] = stack
                 stack = []
-            elif ins.mnemonic == "getstatic":
+            elif ins == "getstatic":
                 const = ins.operands[0]
                 #TODO: Is this the right way to represent a field on the stack?
                 stack.append({"class": const.class_.name.value,
                         "name": const.name_and_type.name.value})
-            elif ins.mnemonic == "invokestatic":
+            elif ins == "invokestatic":
                 const = ins.operands[0]
                 name_index = const.name_and_type.name.index
                 descriptor_index = const.name_and_type.descriptor.index

--- a/burger/toppings/items.py
+++ b/burger/toppings/items.py
@@ -103,7 +103,7 @@ class ItemsTopping(Topping):
             for ins in method.code.disassemble():
                 if ins in ("ldc", "ldc_w"):
                     const = ins.operands[0]
-                    if isinstance(const, String) and const.string.value == "Unable to have damage AND stack.":
+                    if isinstance(const, String) and const == "Unable to have damage AND stack.":
                         max_stack_method = method
                         break
         if not max_stack_method:
@@ -151,7 +151,7 @@ class ItemsTopping(Topping):
                 desc = method_descriptor(method_desc)
 
                 if ins == "invokestatic":
-                    if const.class_.name.value == superclass:
+                    if const.class_.name == superclass:
                         current_item = {}
 
                         text_id = None
@@ -226,7 +226,7 @@ class ItemsTopping(Topping):
                         return object()
 
             def on_get_field(self, ins, const, obj):
-                if const.class_.name.value == blocklist:
+                if const.class_.name == blocklist:
                     # Getting a block; put it on the stack.
                     block_name = aggregate["blocks"]["block_fields"][const.name_and_type.name.value]
                     if block_name not in aggregate["blocks"]["block"]:
@@ -329,7 +329,7 @@ class ItemsTopping(Topping):
                 class_name = const.name.value
 
                 class_file = classloader[class_name]
-                if class_file.super_.name.value == "java/lang/Object":
+                if class_file.super_.name == "java/lang/Object":
                     # A function created for an item shouldn't be counted - we
                     # only want items, not Functions.
                     # I would check directly against the interface but I can't

--- a/burger/toppings/objects.py
+++ b/burger/toppings/objects.py
@@ -68,7 +68,7 @@ class ObjectTopping(Topping):
             if ins == "instanceof":
                 # Check to make sure that it's a spawn packet for item entities
                 const = ins.operands[0]
-                if const.name.value == item_entity_class:
+                if const.name == item_entity_class:
                     will_be_spawn_object_packet = True
             elif ins == "new" and will_be_spawn_object_packet:
                 const = ins.operands[0]

--- a/burger/toppings/objects.py
+++ b/burger/toppings/objects.py
@@ -65,12 +65,12 @@ class ObjectTopping(Topping):
 
         will_be_spawn_object_packet = False
         for ins in createspawnpacket_method.code.disassemble():
-            if ins.mnemonic == "instanceof":
+            if ins == "instanceof":
                 # Check to make sure that it's a spawn packet for item entities
                 const = ins.operands[0]
                 if const.name.value == item_entity_class:
                     will_be_spawn_object_packet = True
-            elif ins.mnemonic == "new" and will_be_spawn_object_packet:
+            elif ins == "new" and will_be_spawn_object_packet:
                 const = ins.operands[0]
                 packet_class_name = const.name.value
                 break
@@ -98,11 +98,11 @@ class ObjectTopping(Topping):
         current_id = 0
 
         for ins in method.code.disassemble():
-            if ins.mnemonic == "if_icmpne":
+            if ins == "if_icmpne":
                 current_id = potential_id
-            elif ins.mnemonic in ("bipush", "sipush"):
+            elif ins in ("bipush", "sipush"):
                 potential_id = ins.operands[0].value
-            elif ins.mnemonic == "new":
+            elif ins == "new":
                 const = ins.operands[0]
                 tmp = {"id": current_id, "class": const.name.value}
                 objects[tmp["id"]] = tmp

--- a/burger/toppings/packetinstructions.py
+++ b/burger/toppings/packetinstructions.py
@@ -526,7 +526,7 @@ class PacketInstructionsTopping(Topping):
                 # Don't attempt to lookup the instruction in the handler
                 pass
 
-            elif instruction.mnemonic in ("istore", "lstore", "fstore", "dstore", "astore"):
+            elif instruction in ("istore", "lstore", "fstore", "dstore", "astore"):
                 # Keep track of what is being stored, for clarity
                 type = _PIT.INSTRUCTION_TYPES[instruction.mnemonic[0]]
                 arg = operands.pop().value
@@ -537,7 +537,7 @@ class PacketInstructionsTopping(Topping):
                                             var=var,
                                             value=stack.pop()))
 
-            elif instruction.mnemonic in ("iastore", "lastore", "fastore", "dastore", "aastore", "bastore", "castore", "sastore"):
+            elif instruction in ("iastore", "lastore", "fastore", "dastore", "aastore", "bastore", "castore", "sastore"):
                 type = _PIT.INSTRUCTION_TYPES[instruction.mnemonic[0]]
 
                 # Array store

--- a/burger/toppings/packets.py
+++ b/burger/toppings/packets.py
@@ -60,14 +60,14 @@ class PacketsTopping(Topping):
         NUM_STATES = 4
 
         for ins in method.code.disassemble():
-            if ins.mnemonic == "new":
+            if ins == "new":
                 const = ins.operands[0]
                 state_class = const.name.value
-            elif ins.mnemonic == "ldc":
+            elif ins == "ldc":
                 const = ins.operands[0]
                 if isinstance(const, String):
                     state_name = const.string.value
-            elif ins.mnemonic == "putstatic":
+            elif ins == "putstatic":
                 const = ins.operands[0]
                 state_field = const.name_and_type.name.value
                 
@@ -95,14 +95,14 @@ class PacketsTopping(Topping):
             direction_class_file = classloader[direction_class]
             direction_init_method = direction_class_file.methods.find_one(name="<clinit>")
             for ins in direction_init_method.code.disassemble():
-                if ins.mnemonic == "new":
+                if ins == "new":
                     const = ins.operands[0]
                     dir_class = const.name.value
-                elif ins.mnemonic == "ldc":
+                elif ins == "ldc":
                     const = ins.operands[0]
                     if isinstance(const, String):
                         dir_name = const.string.value
-                elif ins.mnemonic == "putstatic":
+                elif ins == "putstatic":
                     const = ins.operands[0]
                     dir_field = const.name_and_type.name.value
 
@@ -134,7 +134,7 @@ class PacketsTopping(Topping):
 
             for method in register_methods:
                 for ins in method.code.disassemble():
-                    if ins.mnemonic == "ldc":
+                    if ins == "ldc":
                         const = ins.operands[0]
                         if isinstance(const, String):
                             if "Clientbound" in const.string.value:
@@ -169,17 +169,17 @@ class PacketsTopping(Topping):
             method = cf.methods.find_one(name="<init>")
             init_state()
             for ins in method.code.disassemble():
-                if ins.mnemonic == "getstatic":
+                if ins == "getstatic":
                     const = ins.operands[0]
                     field = const.name_and_type.name.value
                     stack.append(directions_by_field[field])
-                elif ins.mnemonic in ("bipush", "sipush"):
+                elif ins in ("bipush", "sipush"):
                     stack.append(ins.operands[0].value)
-                elif ins.mnemonic in ("ldc", "ldc_w"):
+                elif ins in ("ldc", "ldc_w"):
                     const = ins.operands[0]
                     if isinstance(const, ConstantClass):
                         stack.append("%s.class" % const.name.value)
-                elif ins.mnemonic == "invokevirtual":
+                elif ins == "invokevirtual":
                     # TODO: Currently assuming that the method is the register one which seems to be correct but may be wrong
                     const = ins.operands[0]
                     method_name = const.name_and_type.name.value

--- a/burger/toppings/recipes.py
+++ b/burger/toppings/recipes.py
@@ -297,7 +297,7 @@ class RecipesTopping(Topping):
                     stack.append(i1 - i2);
                 elif ins == "invokespecial":
                     const = ins.operands[0]
-                    if const.name_and_type.name.value == "<init>":
+                    if const.name_and_type.name == "<init>":
                         break
 
             item = get_material(*stack[0])
@@ -358,7 +358,7 @@ class RecipesTopping(Topping):
                             data = ins.operands[0].value
                         elif ins == "invokestatic":
                             const = ins.operands[0]
-                            if const.class_.name.value == "java/lang/Character" and const.name_and_type.name.value == "valueOf":
+                            if const.class_.name == "java/lang/Character" and const.name_and_type.name == "valueOf":
                                 data = chr(data)
                             else:
                                 raise Exception("Unknown method invocation: " + repr(const))
@@ -375,7 +375,7 @@ class RecipesTopping(Topping):
                     const = ins.operands[0]
 
                     recipe_data = {}
-                    if const.name_and_type.name.value == setter_names[0]:
+                    if const.name_and_type.name == setter_names[0]:
                         # Shaped
                         recipe_data['type'] = 'shape'
                         recipe_data['makes'] = crafted_item

--- a/burger/toppings/recipes.py
+++ b/burger/toppings/recipes.py
@@ -268,14 +268,14 @@ class RecipesTopping(Topping):
             stack = []
             while True:
                 ins = itr.next()
-                if ins.mnemonic in ("bipush", "sipush"):
+                if ins in ("bipush", "sipush"):
                     stack.append(ins.operands[0].value)
-                elif ins.mnemonic == "getstatic":
+                elif ins == "getstatic":
                     const = ins.operands[0]
                     clazz = const.class_.name.value
                     name = const.name_and_type.name.value
                     stack.append((clazz, name))
-                elif ins.mnemonic == "invokevirtual":
+                elif ins == "invokevirtual":
                     # TODO: This is a _total_ hack...
                     # We assume that this is an enum, used to get the data value
                     # for the given block.  We also assume that the return value
@@ -284,18 +284,18 @@ class RecipesTopping(Topping):
                     # As I said... ugly.  There's probably a way better way of doing this.
                     dv = int(name, 36) - int('a', 36)
                     stack.append(dv)
-                elif ins.mnemonic == "iadd":
+                elif ins == "iadd":
                     # For whatever reason, there are a few cases where 4 is both
                     # added and subtracted to the enum constant value.
                     # So we need to handle that :/
                     i2 = stack.pop()
                     i1 = stack.pop()
                     stack.append(i1 + i2);
-                elif ins.mnemonic == "isub":
+                elif ins == "isub":
                     i2 = stack.pop()
                     i1 = stack.pop()
                     stack.append(i1 - i2);
-                elif ins.mnemonic == "invokespecial":
+                elif ins == "invokespecial":
                     const = ins.operands[0]
                     if const.name_and_type.name.value == "<init>":
                         break
@@ -328,7 +328,7 @@ class RecipesTopping(Topping):
 
                     ins = itr.next()
                     # Size of the parameter array
-                    if ins.mnemonic in ("bipush", "sipush"):
+                    if ins in ("bipush", "sipush"):
                         param_count = ins.operands[0].value
                     else:
                         raise Exception('Unexpected instruction: expected int constant, got ' + str(ins))
@@ -346,32 +346,32 @@ class RecipesTopping(Topping):
                         # The weirdness here is because characters and strings are
                         # mixed; for example jukebox looks like this:
                         # new Object[] {"###", "#X#", "###", '#', Blocks.PLANKS, 'X', Items.DIAMOND}
-                        if ins.mnemonic == "aastore":
+                        if ins == "aastore":
                             num_astore += 1
                             array.append(data)
                             data = None
-                        elif ins.mnemonic in ("ldc", "ldc_w"):
+                        elif ins in ("ldc", "ldc_w"):
                             const = ins.operands[0]
                             # Separate into a list of characters, to disambiguate (see below)
                             data = list(const.string.value)
-                        if ins.mnemonic in ("bipush", "sipush"):
+                        if ins in ("bipush", "sipush"):
                             data = ins.operands[0].value
-                        elif ins.mnemonic == "invokestatic":
+                        elif ins == "invokestatic":
                             const = ins.operands[0]
                             if const.class_.name.value == "java/lang/Character" and const.name_and_type.name.value == "valueOf":
                                 data = chr(data)
                             else:
                                 raise Exception("Unknown method invocation: " + repr(const))
-                        elif ins.mnemonic == "getstatic":
+                        elif ins == "getstatic":
                             const = ins.operands[0]
                             clazz = const.class_.name.value
                             field = const.name_and_type.name.value
                             data = get_material(clazz, field)
-                        elif ins.mnemonic == "new":
+                        elif ins == "new":
                             data = read_itemstack(itr)
 
                     ins = itr.next()
-                    assert ins.mnemonic == "invokevirtual"
+                    assert ins == "invokevirtual"
                     const = ins.operands[0]
 
                     recipe_data = {}

--- a/burger/toppings/sounds.py
+++ b/burger/toppings/sounds.py
@@ -141,10 +141,10 @@ class SoundTopping(Topping):
         sound_name = None
         sound_id = 0
         for ins in method.code.disassemble():
-            if ins.mnemonic in ('ldc', 'ldc_w'):
+            if ins in ('ldc', 'ldc_w'):
                 const = ins.operands[0]
                 sound_name = const.string.value
-            elif ins.mnemonic == 'invokestatic':
+            elif ins == 'invokestatic':
                 sound = {
                     "name": sound_name,
                     "id": sound_id
@@ -185,10 +185,10 @@ class SoundTopping(Topping):
 
         method = lcf.methods.find_one(name="<clinit>")
         for ins in method.code.disassemble():
-            if ins.mnemonic in ('ldc', 'ldc_w'):
+            if ins in ('ldc', 'ldc_w'):
                 const = ins.operands[0]
                 sound_name = const.string.value
-            elif ins.mnemonic == "putstatic":
+            elif ins == "putstatic":
                 if sound_name is None or sound_name == "Accessed Sounds before Bootstrap!":
                     continue
                 const = ins.operands[0]

--- a/burger/toppings/tileentities.py
+++ b/burger/toppings/tileentities.py
@@ -58,17 +58,17 @@ class TileEntityTopping(Topping):
         te_classes = te.setdefault("classes", {})
         tmp = {}
         for ins in method.code.disassemble():
-            if ins.mnemonic in ("ldc", "ldc_w"):
+            if ins in ("ldc", "ldc_w"):
                 const = ins.operands[0]
                 if isinstance(const, ConstantClass):
                     # Used before 1.13
                     tmp["class"] = const.name.value
                 elif isinstance(const, String):
                     tmp["name"] = const.string.value
-            elif ins.mnemonic == "invokedynamic":
+            elif ins == "invokedynamic":
                 # Used after 1.13
                 tmp["class"] = class_from_invokedynamic(ins, cf)
-            elif ins.mnemonic == "invokestatic":
+            elif ins == "invokestatic":
                 if "class" in tmp and "name" in tmp:
                     tmp["blocks"] = []
                     tileentities[tmp["name"]] = tmp
@@ -90,14 +90,14 @@ class TileEntityTopping(Topping):
 
             num_getstatic = 0
             for ins in method.code.disassemble():
-                if ins.mnemonic == "getstatic":
+                if ins == "getstatic":
                     num_getstatic += 1
                     assert num_getstatic <= num_maps
-                elif ins.mnemonic in ("ldc", "ldc_w") and num_getstatic != 0:
+                elif ins in ("ldc", "ldc_w") and num_getstatic != 0:
                     const = ins.operands[0]
                     if isinstance(const, String):
                         stack.append(const.string.value)
-                elif ins.mnemonic == "invokeinterface":
+                elif ins == "invokeinterface":
                     if len(stack) != 2:
                         if verbose:
                             print("Unexpected stack length for BETag:", stack)
@@ -164,9 +164,9 @@ class TileEntityTopping(Topping):
 
             value = None
             for ins in method.code.disassemble():
-                if ins.mnemonic in ("bipush", "sipush"):
+                if ins in ("bipush", "sipush"):
                     value = ins.operands[0].value
-                elif ins.mnemonic == "instanceof":
+                elif ins == "instanceof":
                     if value is None:
                         # Ensure the command block callback is not counted
                         continue

--- a/burger/toppings/version.py
+++ b/burger/toppings/version.py
@@ -55,9 +55,9 @@ class VersionTopping(Topping):
             looking_for_version_name = False
             for method in cf.methods:
                 for instr in method.code.disassemble():
-                    if instr.mnemonic in ("bipush", "sipush"):
+                    if instr in ("bipush", "sipush"):
                         version = instr.operands[0].value
-                    elif instr.mnemonic == "ldc" and version is not None:
+                    elif instr == "ldc" and version is not None:
                         constant = instr.operands[0]
                         if isinstance(constant, String):
                             str = constant.string.value
@@ -87,7 +87,7 @@ class VersionTopping(Topping):
                 next_ins_is_version = False
                 found_version = None
                 for ins in method.code.disassemble():
-                    if ins.mnemonic in ("ldc", "ldc_w"):
+                    if ins in ("ldc", "ldc_w"):
                         const = ins.operands[0]
                         if isinstance(const, String):
                             if const.string.value == "DataVersion":
@@ -106,7 +106,7 @@ class VersionTopping(Topping):
                             break
                     elif not next_ins_is_version:
                         pass
-                    elif ins.mnemonic in ("bipush", "sipush"):
+                    elif ins in ("bipush", "sipush"):
                         found_version = ins.operands[0].value
 
                 if found_version is not None:

--- a/burger/toppings/version.py
+++ b/burger/toppings/version.py
@@ -90,9 +90,9 @@ class VersionTopping(Topping):
                     if ins in ("ldc", "ldc_w"):
                         const = ins.operands[0]
                         if isinstance(const, String):
-                            if const.string.value == "DataVersion":
+                            if const == "DataVersion":
                                 next_ins_is_version = True
-                            elif const.string.value == "hasLegacyStructureData":
+                            elif const == "hasLegacyStructureData":
                                 # In 18w21a+, there are two places that reference DataVersion,
                                 # one which is querying it and one which is saving it.
                                 # We don't want the one that's querying it;

--- a/burger/util.py
+++ b/burger/util.py
@@ -15,14 +15,14 @@ def class_from_invokedynamic(ins, cf):
     method = cf.constants.get(bootstrap.method_ref)
     # Make sure this is a reference to LambdaMetafactory
     assert method.reference_kind == 6 # REF_invokeStatic
-    assert method.reference.class_.name.value == "java/lang/invoke/LambdaMetafactory"
-    assert method.reference.name_and_type.name.value == "metafactory"
+    assert method.reference.class_.name == "java/lang/invoke/LambdaMetafactory"
+    assert method.reference.name_and_type.name == "metafactory"
     assert len(bootstrap.bootstrap_args) == 3 # Num arguments
     # Now check the arguments.  Note that LambdaMetafactory has some
     # arguments automatically filled in.
     methodhandle = cf.constants.get(bootstrap.bootstrap_args[1])
     assert methodhandle.reference_kind == 8 # REF_newInvokeSpecial
-    assert methodhandle.reference.name_and_type.name.value == "<init>"
+    assert methodhandle.reference.name_and_type.name == "<init>"
     # OK, now that we've done all those checks, just get the type
     # from the constructor.
     return methodhandle.reference.class_.name.value

--- a/burger/util.py
+++ b/burger/util.py
@@ -92,13 +92,13 @@ def walk_method(cf, method, callback, verbose):
     stack = []
     locals = {}
     for ins in method.code.disassemble():
-        if ins.mnemonic in ("bipush", "sipush"):
+        if ins in ("bipush", "sipush"):
             stack.append(ins.operands[0].value)
         elif ins.mnemonic.startswith("fconst"):
             stack.append(float(ins.mnemonic[-1]))
-        elif ins.mnemonic == "aconst_null":
+        elif ins == "aconst_null":
             stack.append(None)
-        elif ins.mnemonic in ("ldc", "ldc_w"):
+        elif ins in ("ldc", "ldc_w"):
             const = ins.operands[0]
 
             if isinstance(const, ConstantClass):
@@ -107,14 +107,14 @@ def walk_method(cf, method, callback, verbose):
                 stack.append(const.string.value)
             else:
                 stack.append(const.value)
-        elif ins.mnemonic == "new":
+        elif ins == "new":
             const = ins.operands[0]
 
             try:
                 stack.append(callback.on_new(ins, const))
             except StopIteration:
                 break
-        elif ins.mnemonic in ("getfield", "getstatic"):
+        elif ins in ("getfield", "getstatic"):
             const = ins.operands[0]
             if ins.mnemonic != "getstatic":
                 obj = stack.pop()
@@ -125,7 +125,7 @@ def walk_method(cf, method, callback, verbose):
                 stack.append(callback.on_get_field(ins, const, obj))
             except StopIteration:
                 break
-        elif ins.mnemonic in ("putfield", "putstatic"):
+        elif ins in ("putfield", "putstatic"):
             const = ins.operands[0]
             value = stack.pop()
             if ins.mnemonic != "putstatic":
@@ -137,7 +137,7 @@ def walk_method(cf, method, callback, verbose):
                 callback.on_put_field(ins, const, obj, value)
             except StopIteration:
                 break
-        elif ins.mnemonic in ("invokevirtual", "invokespecial", "invokeinterface", "invokestatic"):
+        elif ins in ("invokevirtual", "invokespecial", "invokeinterface", "invokestatic"):
             const = ins.operands[0]
             method_desc = const.name_and_type.descriptor.value
             desc = method_descriptor(method_desc)
@@ -158,13 +158,13 @@ def walk_method(cf, method, callback, verbose):
                 break
             if desc.returns.name != "void":
                 stack.append(ret)
-        elif ins.mnemonic == "astore":
+        elif ins == "astore":
             locals[ins.operands[0].value] = stack.pop()
-        elif ins.mnemonic == "aload":
+        elif ins == "aload":
             stack.append(locals[ins.operands[0].value])
-        elif ins.mnemonic == "dup":
+        elif ins == "dup":
             stack.append(stack[-1])
-        elif ins.mnemonic in ("checkcast", "return"):
+        elif ins in ("checkcast", "return"):
             pass
         elif verbose:
             print("Unknown instruction %s: stack is %s" % (ins, stack))


### PR DESCRIPTION
These features were added in tktech/jawa@c1bc2cefa167db6c9a554d1b68b86f6715a7e2e7 and tktech/jawa@23f93020ef6687567e45a9afa09bfd6e0faf6f0a.

Some gotcha's I encountered when implementing these:

* For instructions, you cannot use `!=`.  This came up in some of my code where I checked for all field or invoke instructions and then checked in a second place for the static variants:

    https://github.com/mcdevs/Burger/blob/02f9537c4f7982d14391a786509c0756e5a4a490/burger/util.py#L117-L122

* You cannot use `in` with these in some cases -- I ran into this when using a classname with a `set()`; it fails as UTF8 is not hashable.  This does seem to work with tuples for instructions though.

    https://github.com/mcdevs/Burger/blob/02f9537c4f7982d14391a786509c0756e5a4a490/burger/toppings/blockstates.py#L68
    https://github.com/mcdevs/Burger/blob/02f9537c4f7982d14391a786509c0756e5a4a490/burger/toppings/blockstates.py#L218-L223

* `Operand`s changed by `expand_constants` that are numeric don't seem to be effected, unless I'm doing something wrong; while I can write `const = ins.operands[0]` I cannot do `ins.operands[0] == 128`.  This isn't exactly related to the above changes but was something I ran into.