### PR TITLE
Setup and use fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,24 @@ a few specifically. Each topping is then aggregated by
 
 ## Usage
 The simplest way to use Burger is to pass the `-d` or `--download`
-flag, which will download the minecraft client for you.
+flag, which will download the specified minecraft client for you.
+This option can be specified multiple times.  The downloaded jar will be saved
+in the working directory, and if it already exists the existing verison will be used.
 
-    $ python munch.py --download
+    $ python munch.py --download 1.13.2
+
+To download the latest snapshot, `-D` or `--download-latest` can be used.
+
+    $ python munch.py -D
 
 Alternatively, you can specify the client JAR by passing it as an argument.
 
     $ python munch.py 1.8.jar
 
 You can redirect the output from the default `stdout` by passing
-`-o <path>` or `--output <path>`.
-    
+`-o <path>` or `--output <path>`.  This is useful when combined with
+verbose output (`-v` or `--verbose`) so that the output doesn't go into the file.
+
     $ python munch.py -d --output output.json
 
 You can see what toppings are available by passing `-l` or `--list`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can redirect the output from the default `stdout` by passing
 `-o <path>` or `--output <path>`.  This is useful when combined with
 verbose output (`-v` or `--verbose`) so that the output doesn't go into the file.
 
-    $ python munch.py -d --output output.json
+    $ python munch.py -D --output output.json
 
 You can see what toppings are available by passing `-l` or `--list`.
 
@@ -41,7 +41,7 @@ missing a dependency, it will output an error telling you what
 also needs to be included.  Toppings will generally automatically load
 their dependencies, however.
 
-    $ python munch.py -d --toppings language,stats
+    $ python munch.py -D --toppings language,stats
 
 The above example would only extract the language information, as
 well as the stats and achievements (both part of `stats`).

--- a/burger/toppings/sounds.py
+++ b/burger/toppings/sounds.py
@@ -32,7 +32,7 @@ import traceback
 import six
 import six.moves.urllib.request
 
-from burger.website import Website
+from burger import website
 from .topping import Topping
 
 from jawa.constants import *
@@ -71,14 +71,14 @@ class SoundTopping(Topping):
     def act(aggregate, classloader, verbose=False):
         sounds = aggregate.setdefault('sounds', {})
         try:
-            version_meta = Website.get_version_meta(aggregate["version"]["name"], verbose)
+            version_meta = website.get_version_meta(aggregate["version"]["name"], verbose)
         except Exception as e:
             if verbose:
                 print("Error: Failed to download version meta for sounds: %s" % e)
                 traceback.print_exc()
             return
         try:
-            assets = Website.get_asset_index(version_meta, verbose)
+            assets = website.get_asset_index(version_meta, verbose)
         except Exception as e:
             if verbose:
                 print("Error: Failed to download asset index for sounds: %s" % e)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url="http://github.com/mcdevs/Burger",
     keywords=["java", "minecraft"],
     install_requires=[
-        'Jawa>=2.0'
+        'Jawa>=2.2.0'
     ],
     dependency_links=[
         'https://github.com/tktech/Jawa/tarball/master#egg=Jawa'


### PR DESCRIPTION
3 things:

* Fix the jawa version in `install_requires` (#26)
* Continue running other toppings if one topping fails, as long as they aren't dependencies (i.e. give some output such as versions and packets even if blocks or items fail)
* Re-implement the download function, which has been strange-behaving since 1.6 allowed selecting arbitrary versions in the launcher.