### PR TITLE
Use the id field in the verison.json to determine the version's json file on the download site

### DIFF
--- a/burger/toppings/sounds.py
+++ b/burger/toppings/sounds.py
@@ -78,7 +78,7 @@ class SoundTopping(Topping):
             return
 
         try:
-            version_meta = website.get_version_meta(aggregate["version"]["name"], verbose)
+            version_meta = website.get_version_meta(aggregate["version"]["id"], verbose)
         except Exception as e:
             if verbose:
                 print("Error: Failed to download version meta for sounds: %s" % e)

--- a/burger/website.py
+++ b/burger/website.py
@@ -90,6 +90,8 @@ def client_jar(version, verbose):
     filename = version + ".jar"
     if not os.path.exists(filename):
         meta = get_version_meta(version, verbose)
+        if verbose:
+            print("For version %s, the downloads section of the meta is %s" % (filename, meta["downloads"]))
         url = meta["downloads"]["client"]["url"]
         if verbose:
             print("Downloading %s from %s" % (version, url))


### PR DESCRIPTION
This fixes sounds in the 1.14.3 prereleases.

Starting with 1.14.3-pre1, the `id` field began being used for the id used on the downloads site.  Prior to that (1.14.2), `name` was used, and `id` looked like `1.14.2 / f647ba8dc371474797bee24b2b312ff4`.  The hexadecimal string there had (to my understanding) no meaning; it definitely was not correlated with the download itself.  Now, `name` is e.g. `1.14.3 Pre-Release 1`, while `id` is `1.14.3-pre1`.