### PR TITLE
Add six as an install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     url="http://github.com/mcdevs/Burger",
     keywords=["java", "minecraft"],
     install_requires=[
+        'six>=1.4.0',
         'Jawa>=2.2.0,<3'
     ],
     classifiers=[


### PR DESCRIPTION
All toppings work with `six==1.4.0`, and should work with later versions.